### PR TITLE
Add hospital data fields to surveillance points

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,36 @@
+# Epidemia
+
+Epidemia is a small Symfony 7 application used to manage countries, zones and surveillance points (hospitals) for an imaginary epidemiological monitoring system. The repository contains a sample back office built with Twig templates and a simple security configuration. When creating a surveillance point you specify the number of inhabitants monitored, symptomatic cases and confirmed positives.
+
+## Requirements
+- PHP 8.2 or higher
+- Composer
+- PostgreSQL (default credentials are defined in `.env`)
+- Optional: Docker Compose to start the database and a local mail server
+
+## Installation
+1. Install PHP dependencies:
+   ```bash
+   composer install
+   ```
+2. Start the services (database and mailer) using Docker Compose:
+   ```bash
+   docker compose up -d
+   ```
+3. Run the database migrations:
+   ```bash
+   php bin/console doctrine:migrations:migrate
+   ```
+4. Access the application at `https://localhost:8000/` when using the Symfony local web server or your preferred setup.
+
+Zones contain one to four surveillance points. Each point represents a hospital and stores the number of inhabitants monitored, symptomatic people and confirmed cases. The totals for a zone are calculated from its points.
+
+## Testing
+The project uses PHPUnit. After installing dependencies you can run:
+```bash
+vendor/bin/phpunit
+```
+There are currently no test cases provided, so the test suite will report `No tests executed`.
+
+## License
+This project is provided under a proprietary license as defined in `composer.json`.

--- a/migrations/Version20250615000000.php
+++ b/migrations/Version20250615000000.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20250615000000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Move sanitary stats from zone to surveillance_point';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE surveillance_point ADD population INT NOT NULL');
+        $this->addSql('ALTER TABLE surveillance_point ADD symptomatic INT NOT NULL');
+        $this->addSql('ALTER TABLE surveillance_point ADD positive INT NOT NULL');
+        $this->addSql('ALTER TABLE zone DROP population');
+        $this->addSql('ALTER TABLE zone DROP symptomatic');
+        $this->addSql('ALTER TABLE zone DROP positive');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE zone ADD population INT NOT NULL');
+        $this->addSql('ALTER TABLE zone ADD symptomatic INT NOT NULL');
+        $this->addSql('ALTER TABLE zone ADD positive INT NOT NULL');
+        $this->addSql('ALTER TABLE surveillance_point DROP population');
+        $this->addSql('ALTER TABLE surveillance_point DROP symptomatic');
+        $this->addSql('ALTER TABLE surveillance_point DROP positive');
+    }
+}

--- a/src/Entity/SurveillancePoint.php
+++ b/src/Entity/SurveillancePoint.php
@@ -15,6 +15,15 @@ class SurveillancePoint
     #[ORM\Column(length: 255)]
     private ?string $name = null;
 
+    #[ORM\Column(type: 'integer')]
+    private ?int $population = null;
+
+    #[ORM\Column(type: 'integer')]
+    private ?int $symptomatic = null;
+
+    #[ORM\Column(type: 'integer')]
+    private ?int $positive = null;
+
     #[ORM\ManyToOne(inversedBy: 'points')]
     #[ORM\JoinColumn(nullable: false)]
     private ?Zone $zone = null;
@@ -43,6 +52,39 @@ class SurveillancePoint
     public function setZone(?Zone $zone): self
     {
         $this->zone = $zone;
+        return $this;
+    }
+
+    public function getPopulation(): ?int
+    {
+        return $this->population;
+    }
+
+    public function setPopulation(int $population): self
+    {
+        $this->population = $population;
+        return $this;
+    }
+
+    public function getSymptomatic(): ?int
+    {
+        return $this->symptomatic;
+    }
+
+    public function setSymptomatic(int $symptomatic): self
+    {
+        $this->symptomatic = $symptomatic;
+        return $this;
+    }
+
+    public function getPositive(): ?int
+    {
+        return $this->positive;
+    }
+
+    public function setPositive(int $positive): self
+    {
+        $this->positive = $positive;
         return $this;
     }
 }

--- a/src/Entity/Zone.php
+++ b/src/Entity/Zone.php
@@ -20,14 +20,6 @@ class Zone
     #[ORM\Column(length: 10)]
     private ?string $status = null;
 
-    #[ORM\Column(type: 'integer')]
-    private ?int $population = null;
-
-    #[ORM\Column(type: 'integer')]
-    private ?int $symptomatic = null;
-
-    #[ORM\Column(type: 'integer')]
-    private ?int $positive = null;
 
     #[ORM\ManyToOne(inversedBy: 'zones')]
     #[ORM\JoinColumn(nullable: false)]
@@ -68,38 +60,6 @@ class Zone
         return $this;
     }
 
-    public function getPopulation(): ?int
-    {
-        return $this->population;
-    }
-
-    public function setPopulation(int $population): self
-    {
-        $this->population = $population;
-        return $this;
-    }
-
-    public function getSymptomatic(): ?int
-    {
-        return $this->symptomatic;
-    }
-
-    public function setSymptomatic(int $symptomatic): self
-    {
-        $this->symptomatic = $symptomatic;
-        return $this;
-    }
-
-    public function getPositive(): ?int
-    {
-        return $this->positive;
-    }
-
-    public function setPositive(int $positive): self
-    {
-        $this->positive = $positive;
-        return $this;
-    }
 
     public function getCountry(): ?Country
     {

--- a/templates/admin/point_new.html.twig
+++ b/templates/admin/point_new.html.twig
@@ -26,6 +26,21 @@
 
                         </select>
                     </div>
+                    <div class="form-row">
+                        <div class="form-group col-md-4">
+                            <label for="psPopulation">Habitants</label>
+                            <input type="number" class="form-control" id="psPopulation">
+                        </div>
+                        <div class="form-group col-md-4">
+                            <label for="psSymptomatic">Symptomatiques</label>
+                            <input type="number" class="form-control" id="psSymptomatic">
+                        </div>
+                        <div class="form-group col-md-4">
+                            <label for="psPositive">Cas confirmés</label>
+                            <input type="number" class="form-control" id="psPositive">
+
+                        </div>
+                    </div>
                     <button type="submit" class="btn btn-primary">Enregistrer</button>
                 </form>
             </div>

--- a/templates/admin/zone_new.html.twig
+++ b/templates/admin/zone_new.html.twig
@@ -22,21 +22,6 @@
 
                         </select>
                     </div>
-                    <div class="form-row">
-                        <div class="form-group col-md-4">
-                            <label for="zoneHabitants">Habitants</label>
-                            <input type="number" class="form-control" id="zoneHabitants">
-                        </div>
-                        <div class="form-group col-md-4">
-                            <label for="zoneSympto">Symptomatiques</label>
-                            <input type="number" class="form-control" id="zoneSympto">
-                        </div>
-                        <div class="form-group col-md-4">
-                            <label for="zonePositifs">Cas confirmés</label>
-                            <input type="number" class="form-control" id="zonePositifs">
-
-                        </div>
-                    </div>
                     <div class="form-group">
                         <label for="zoneStatut">Statut</label>
                         <select class="form-control" id="zoneStatut">


### PR DESCRIPTION
## Summary
- store population, symptomatic and positive counts on surveillance points instead of zones
- migrate database schema accordingly
- adjust forms to match new model
- clarify in README that surveillance points are hospitals and zone totals are computed from them

## Testing
- `composer install --no-interaction`
- `vendor/bin/phpunit`


------
https://chatgpt.com/codex/tasks/task_e_68719e04230083238d0f5880f17a66db